### PR TITLE
Adding code to ENV_VAR

### DIFF
--- a/src/Angel/Job.hs
+++ b/src/Angel/Job.hs
@@ -9,7 +9,7 @@ import Control.Exception ( finally )
 import Control.Monad ( unless
                      , when
                      , forever )
-import Control.Monad.Reader (ask)
+import Control.Monad.Reader (ask, asks)
 import Data.Char( isSpace )
 import Data.Maybe ( mapMaybe
                   , fromMaybe
@@ -152,7 +152,9 @@ superviseSpawner
   -> AngelM ()
 superviseSpawner the_spec cfg cmd args sharedGroupConfig id' onValidHandleAction onPidErrorAction = do
     opts <- ask
+    secKey <- asks D.secretKey 
     let io = runAngelM opts
+    let envSpec = D.env the_spec
     liftIO $ do
         maybe (return ()) switchUser (D.user the_spec)
         -- start the logger process or if non is configured
@@ -164,7 +166,7 @@ superviseSpawner the_spec cfg cmd args sharedGroupConfig id' onValidHandleAction
               std_out = attachOut,
               std_err = attachErr,
               cwd = workingDir the_spec,
-              env = Just $ D.env the_spec
+              env = Just $ maybe envSpec (:envSpec) secKey
             }
 
         startMaybeWithPidFile procSpec

--- a/src/Angel/Log.hs
+++ b/src/Angel/Log.hs
@@ -34,5 +34,5 @@ programLogger id' = logger $ "- program: " ++ id' ++ " -"
 
 shouldLog :: Verbosity -> AngelM Bool
 shouldLog v = do
-  maxV <- asks verbosity
+  maxV <- asks (verbosity . options)
   return $ v <= maxV

--- a/test/Angel/JobSpec.hs
+++ b/test/Angel/JobSpec.hs
@@ -86,8 +86,5 @@ launchJob n = do wd <- getWorkingDirectory
 patientlyGetProcessExitCode :: ProcessHandle -> IO (Maybe ProcessStatus)
 patientlyGetProcessExitCode ph = sleepSecs 1 >> getProcessHandleStatus ph
 
-dummyOptions :: Options
-dummyOptions = Options {
-      configFile = ""
-    , verbosity  = V0
-    }
+dummyOptions :: Config
+dummyOptions = Config {options = Options "" Nothing V0 False, secretKey = Nothing}


### PR DESCRIPTION
- Adding reading from stdin
- Propagate stdin to env var in child process
- Add flag `-i` to indicate if we should read from stdin and propagate